### PR TITLE
mark unsafe as forbidden

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-#[deny(unsafe_code)]
+#![forbid(unsafe_code)]
+
 mod jhash;
 
 pub use jhash::*;


### PR DESCRIPTION
This makes tools such as `cargo geiger` mark the crate as safe.